### PR TITLE
Use the public app names, instead of the ids

### DIFF
--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -81,8 +81,6 @@ const GetStarted = () => {
 	>();
 
 	React.useEffect(() => {
-		const appIds = [1635296, 1635297];
-
 		sdk.models.config
 			.getDeviceTypes()
 			.then((res) =>
@@ -96,7 +94,13 @@ const GetStarted = () => {
 				options: {
 					$select: ['id', 'device_type', 'app_name'],
 					$filter: {
-						id: { $in: appIds },
+						is_public: true,
+						slug: {
+							$in: [
+								'balenalabs/rosetta-at-home-amd64',
+								'balenalabs/rosetta-at-home-arm',
+							],
+						},
 					},
 				},
 			})


### PR DESCRIPTION
The slug is the way that we should reference public apps.
I was initially thinking about doing:
```
await sdk.pine.get({
    resource: 'application',
    options: {
        $select: ['id', 'device_type', 'app_name'],
        $filter: {
            is_public: true,
            slug: {$startswith: 'balenalabs/rosetta-at-home'}
        },
    },
})
```
But ended up deciding doing in a way that will prevent new apps from showing app unintentionally.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>