### PR TITLE
Redirects foldforcovid.com to foldforcovid.io.

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,5 @@
+https://foldforcovid.com https://foldforcovid.io
+https://www.foldforcovid.com https://foldforcovid.io
+http://foldforcovid.com https://foldforcovid.io
+http://www.foldforcovid.com https://foldforcovid.io
 /* /index.html 200


### PR DESCRIPTION
A `_redirects` file was added to redirect foldforcovid.com to foldforcovid.io.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>