### PR TITLE
Redirects to / instead of /index.html.

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,5 @@
-http://foldforcovid.com/* https://foldforcovid.io/index.html 301!
-http://www.foldforcovid.com/* https://foldforcovid.io/index.html 301!
-https://foldforcovid.com/* https://foldforcovid.io/index.html 301!
-https://www.foldforcovid.com/* https://foldforcovid.io/index.html 301!
+http://foldforcovid.com/* https://foldforcovid.io/ 301!
+http://www.foldforcovid.com/* https://foldforcovid.io/ 301!
+https://foldforcovid.com/* https://foldforcovid.io/ 301!
+https://www.foldforcovid.com/* https://foldforcovid.io/ 301!
 /* /index.html 200


### PR DESCRIPTION
Accessing index.html directly breaks the page.
    
    Change-type: patch
    Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>