### PR TITLE
Fixing forum link on foldforcovid landing page

### DIFF
--- a/src/components/FAQs.tsx
+++ b/src/components/FAQs.tsx
@@ -34,7 +34,7 @@ const faqs = [
 				Try the project out, come join us on the{' '}
 				<ExternalLink
 					label="Forums"
-					href="https://forums.balena.io/c/fold-for-covid/"
+					href="https://forums.balena.io/c/project-help/fold-for-covid/83"
 				/>
 				, submit fixes or improvements, or add features to the{' '}
 				<ExternalLink
@@ -205,7 +205,7 @@ const faqs = [
 			<>
 				Let us know in{' '}
 				<ExternalLink
-					href="https://forums.balena.io/c/fold-for-covid/"
+					href="https://forums.balena.io/c/project-help/fold-for-covid/83"
 					label="our Forums!"
 				/>
 			</>
@@ -242,7 +242,7 @@ const FAQs = () => {
 					mx={3}
 					target="_blank"
 					primary
-					href="https://forums.balena.io/c/fold-for-covid/"
+					href="https://forums.balena.io/c/project-help/fold-for-covid/83"
 				>
 					See forums
 				</Button>

--- a/src/components/Forum.tsx
+++ b/src/components/Forum.tsx
@@ -23,7 +23,7 @@ const Forum = () => {
 				<Button
 					primary
 					target="_blank"
-					href="https://forums.balena.io/c/fold-for-covid/"
+					href="https://forums.balena.io/c/project-help/fold-for-covid/83"
 				>
 					See forums
 				</Button>


### PR DESCRIPTION
Fixing broken/404 link on foldforcovid landing page to instead point to
new forum area for foldforcovid.

Change-type: patch
Signed-off-by: Andrew Nhem <andrewn@balena.io>